### PR TITLE
[Bug #10]: Display sum count of displayed crimes in popup

### DIFF
--- a/client/denver/data/configs/viewerConfig.json
+++ b/client/denver/data/configs/viewerConfig.json
@@ -402,7 +402,8 @@
                     },
                     "viewParamsMap": {
                         "from": "mo_min",
-                        "to": "mo_max"
+                        "to": "mo_max",
+                        "category": "crime_type"
                     },
                     "pointerMovePopup": {
                         "fields": [

--- a/client/new-york/data/configs/viewerConfig.json
+++ b/client/new-york/data/configs/viewerConfig.json
@@ -369,7 +369,8 @@
                     },
                     "viewParamsMap": {
                         "from": "mo_min",
-                        "to": "mo_max"
+                        "to": "mo_max",
+                        "category": "event_type"
                     },
                     "pointerMovePopup": {
                         "fields": [

--- a/client/nyc-311/data/configs/viewerConfig.json
+++ b/client/nyc-311/data/configs/viewerConfig.json
@@ -364,7 +364,8 @@
                     },
                     "viewParamsMap": {
                         "from": "mo_min",
-                        "to": "mo_max"
+                        "to": "mo_max",
+                        "category": "event_type"
                     },
                     "pointerMovePopup": {
                         "fields": [

--- a/packages/mapstore-events-tracker/js/components/OLFeaturesPopup.jsx
+++ b/packages/mapstore-events-tracker/js/components/OLFeaturesPopup.jsx
@@ -65,24 +65,6 @@ function OLFeaturesPopup({
         };
     }
 
-    function getPrecinctTotalCount(currentPopupData) {
-        let totalCount = 0;
-        let popupData = [...currentPopupData];
-        for (let popup of popupData) {
-            if (popup?.props?.fields) {
-                for (let field of popup.props.fields) {
-                    if (field.id && Number.isInteger(field.value)) {
-                        totalCount = totalCount + field.value;
-
-                    }
-                }
-                const totalCountIndex = popup.props.fields.findIndex(item => !item?.id && item.labelId);
-                popup.props.fields[totalCountIndex].value = totalCount;
-            }
-        }
-        return popupData;
-    }
-
     function getPopupProps({
         layer,
         featureProperties,
@@ -224,18 +206,14 @@ function OLFeaturesPopup({
         };
     }, [map]);
 
-    const popupsData = getPrecinctTotalCount(popups);
     return map
         ? (
             <>
-                {
-                    popupsData && <PopupSupport
-                        map={map}
-                        popups={popupsData}
-                        onPopupClose={handleClosePopup}
-                    />
-                }
-
+                <PopupSupport
+                    map={map}
+                    popups={popups}
+                    onPopupClose={handleClosePopup}
+                />
             </>
         )
         : null;

--- a/packages/mapstore-events-tracker/js/components/OLFeaturesPopup.jsx
+++ b/packages/mapstore-events-tracker/js/components/OLFeaturesPopup.jsx
@@ -65,6 +65,24 @@ function OLFeaturesPopup({
         };
     }
 
+    function getPrecinctTotalCount(currentPopupData) {
+        let totalCount = 0;
+        let popupData = [...currentPopupData];
+        for (let popup of popupData) {
+            if (popup?.props?.fields) {
+                for (let field of popup.props.fields) {
+                    if (field.id && Number.isInteger(field.value)) {
+                        totalCount = totalCount + field.value;
+
+                    }
+                }
+                const totalCountIndex = popup.props.fields.findIndex(item => !item?.id && item.labelId);
+                popup.props.fields[totalCountIndex].value = totalCount;
+            }
+        }
+        return popupData;
+    }
+
     function getPopupProps({
         layer,
         featureProperties,
@@ -206,14 +224,18 @@ function OLFeaturesPopup({
         };
     }, [map]);
 
+    const popupsData = getPrecinctTotalCount(popups);
     return map
         ? (
             <>
-                <PopupSupport
-                    map={map}
-                    popups={popups}
-                    onPopupClose={handleClosePopup}
-                />
+                {
+                    popupsData && <PopupSupport
+                        map={map}
+                        popups={popupsData}
+                        onPopupClose={handleClosePopup}
+                    />
+                }
+
             </>
         )
         : null;


### PR DESCRIPTION
This PR fixes a bug that was displaying the total count of all crimes instead of the sum of the crimes displayed in the popup as described in issue #10

https://user-images.githubusercontent.com/1873416/150118085-f05ab59d-e7b7-4770-8298-d3c45717e943.mp4

 