### PR TITLE
[Issue #7]: updated hover effects for counter cards

### DIFF
--- a/packages/mapstore-events-tracker/themes/default/less/viewer.less
+++ b/packages/mapstore-events-tracker/themes/default/less/viewer.less
@@ -18,9 +18,14 @@
 @ms-viewer-scrollbar-thumb-bg: @ms-main-variant-bg;
 @ms-viewer-scrollbar-thumb-hover-bg: @ms-main-hover-bg;
 
+@ms-counter-hover-bg: #1B9CFC;
+@ms-counter-hover-color: #ffffff;
+
 #ms-components-theme(@themevars) {
     .ms-viewer-counters {
         .ms-viewer-counter {
+            border-radius: 5px;
+            overflow: hidden;
             > a {
                 .color-var(@theme-vars[main-color]);
             }
@@ -28,6 +33,13 @@
             &.selected * {
                 .color-var(@theme-vars[primary-contrast]);
                 .background-color-var(@theme-vars[primary]);
+            }
+            &:hover {
+                background-color: @ms-counter-hover-bg;
+                box-shadow: 0 5px 20px 0 rgba(0,0,0,0.35);
+                span {
+                    color: @ms-counter-hover-color;
+                }
             }
             
         }


### PR DESCRIPTION
This PR adds hover effects to crime counter cards as described in Issue #7 

https://user-images.githubusercontent.com/1873416/150813373-84ab4b1b-3cd3-484e-8518-2768004546b7.mp4

