### PR TITLE
[Issue #8]: switch to detail on clicking row in crimes count table

### DIFF
--- a/packages/mapstore-events-tracker/js/components/FeaturesTable.js
+++ b/packages/mapstore-events-tracker/js/components/FeaturesTable.js
@@ -62,7 +62,6 @@ function FeaturesTable({
                         );
                     })}
                     <th></th>
-                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -104,11 +103,6 @@ function FeaturesTable({
                                             : null;
                                     })}
                                 </svg>
-                            </td>
-                            <td>
-                                <a href={`#/?feature-viz=detail&feature=${row.pct.value}`}>
-                                    Details
-                                </a>
                             </td>
                         </tr>
                     );

--- a/packages/mapstore-events-tracker/js/components/FeaturesTable.js
+++ b/packages/mapstore-events-tracker/js/components/FeaturesTable.js
@@ -59,6 +59,7 @@ function FeaturesTable({
                         );
                     })}
                     <th></th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -90,6 +91,11 @@ function FeaturesTable({
                                             : null;
                                     })}
                                 </svg>
+                            </td>
+                            <td>
+                                <a href={`#/?feature-viz=detail&feature=${row.pct.value}`}>
+                                    Details
+                                </a>
                             </td>
                         </tr>
                     );

--- a/packages/mapstore-events-tracker/themes/default/less/viewer.less
+++ b/packages/mapstore-events-tracker/themes/default/less/viewer.less
@@ -65,6 +65,9 @@
             .background-color-var(@theme-vars[main-bg]);
             .border-bottom-color-var(@theme-vars[main-border-color]);
         }
+        a:hover {
+            text-decoration: underline;
+        }
     }
 
     #map-search-bar {


### PR DESCRIPTION
This pull request redirects a user to the detail of crime count in a precinct by clicking the "Details" button


https://user-images.githubusercontent.com/1873416/150958433-d1c3a574-5725-48a0-8fbb-e0735a6279a4.mp4


